### PR TITLE
Solution

### DIFF
--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -25,7 +25,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         'key': 'id',
         'equals': request.params.id
       });
-      return memberType!!;
+      if (memberType) {
+        return memberType;
+      } else {
+        throw reply.notFound();
+      }
     }
   );
 
@@ -39,7 +43,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply): Promise<MemberTypeEntity> {
       try {
-        return fastify.db.memberTypes.change(request.params.id, request.body);
+        let patched = await fastify.db.memberTypes.change(
+          request.params.id, request.body
+        );
+        return patched;
       } catch (err) {
         if (err instanceof NoRequiredEntity) {
           throw reply.badRequest();

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -2,13 +2,16 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { changeMemberTypeBodySchema } from './schema';
 import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
+import { NoRequiredEntity } from '../../utils/DB/errors/NoRequireEntity.error';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     MemberTypeEntity[]
-  > {});
+  > {
+    return fastify.db.memberTypes.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +20,13 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      let memberType = await fastify.db.memberTypes.findOne({
+        'key': 'id',
+        'equals': request.params.id
+      });
+      return memberType!!;
+    }
   );
 
   fastify.patch(
@@ -28,7 +37,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      try {
+        return fastify.db.memberTypes.change(request.params.id, request.body);
+      } catch (err) {
+        if (err instanceof NoRequiredEntity) {
+          throw reply.badRequest();
+        };
+        throw err;
+      };
+    }
   );
 };
 

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -23,7 +23,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         'key': 'id',
         'equals': request.params.id
       });
-      return post!!;
+      if (post) {
+        return post;
+      } else {
+        throw reply.notFound();
+      };
     }
   );
 
@@ -47,7 +51,17 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<PostEntity> {
-      return fastify.db.posts.delete(request.params.id);
+      try {
+        let deleted = await fastify.db.posts.delete(
+          request.params.id
+        );
+        return deleted;
+      } catch (err) {
+        if (err instanceof NoRequiredEntity) {
+          throw reply.badRequest();
+        };
+        throw err;
+      };
     }
   );
 
@@ -61,7 +75,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply): Promise<PostEntity> {
       try {
-        return fastify.db.posts.change(request.params.id, request.body);
+        let patched = await fastify.db.posts.change(
+          request.params.id, request.body
+        );
+        return patched;
       } catch (err) {
         if (err instanceof NoRequiredEntity) {
           throw reply.badRequest();


### PR DESCRIPTION
# Total: -

## Basic Scope
- [x] **+72** Task 1: restful endpoints.
- [ ] **+72** Subtasks 2.1-2.7: get gql queries.
- [ ] **+54** Subtasks 2.8-2.11: create gql queries.
- [ ] **+54** Subtasks 2.12-2.17: update gql queries.
- [ ] **+88** Task 3: solve `n+1` graphql problem.
- [ ] **+20** Task 4: limit the complexity of the graphql queries.

## Forfeits
- [ ] **-30% of max task score** Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
- [ ] **-60% of max task score** Samples of POST body for gql requests were not provided for those subtasks that were declared to be completed.
- [ ] **-100% of max task score** Tests have been modified.
- [ ] **-20** No separate development branch
- [ ] **-20** No Pull Request
- [ ] **-10** Pull Request description is incorrect
- [ ] **-20** Less than 3 commits in the development branch, not including commits that make changes only to `Readme.md` or similar files (`tsconfig.json`, `.gitignore`, `.prettierrc.json`, etc.)
